### PR TITLE
adding failing test case

### DIFF
--- a/tests/tree/dpt_test.cpp
+++ b/tests/tree/dpt_test.cpp
@@ -77,6 +77,7 @@ TEST_F(dpt_test, existential_batched_existing) {
   q_list queries = gen_random_existing_queries(2000, 10);
   auto results = dpt_.existential_batched<dpt::com::collective_communication>(
     std::move(queries));
+  ASSERT_EQ(2000, results.size());
   for (const auto& result : results) {
     ASSERT_EQ(dpt::tree::search_state::MATCH, result);
   }


### PR DESCRIPTION
The number of results returned by dpt query functions should be the same as the number of queries given.
A lot of existing queries fail in the `global_trie.first_and_last_occurrence`, returning something else than `search_state::MATCH`.