### PR TITLE
Fixing multiple problems

### DIFF
--- a/dpt/tree/distributed_patricia_trie.hpp
+++ b/dpt/tree/distributed_patricia_trie.hpp
@@ -75,8 +75,8 @@ public:
         target_pes[i] = -1;
       }
     }
-    std::vector<GlobalIndex> displ(env_.size(), 0);
-    std::vector<GlobalIndex> displ_length(env_.size(), 0);
+    std::vector<size_t> displ(env_.size(), 0);
+    std::vector<size_t> displ_length(env_.size(), 0);
     for (int32_t i = 1; i < env_.size(); ++i) {
       displ[i] = displ[i - 1] + hist[i - 1];
       displ_length[i] = displ_length[i - 1] + hist_length[i - 1];
@@ -89,6 +89,7 @@ public:
         std::copy_n(queries[i].query, queries[i].length, 
           queries_to_distribute.begin() + displ_length[target_pes[i]]);
         displ_length[target_pes[i]] += queries[i].length;
+        lengths_to_distribute[displ[target_pes[i]]++] = queries[i].length;
       }
     }
     q_list rec_queries = manager_.template distribute_queries<Communication>(
@@ -117,8 +118,8 @@ public:
         target_pes[i] = std::make_pair(-1, -1);
       }
     }
-    std::vector<GlobalIndex> displ(env_.size(), 0);
-    std::vector<GlobalIndex> displ_length(env_.size(), 0);
+    std::vector<size_t> displ(env_.size(), 0);
+    std::vector<size_t> displ_length(env_.size(), 0);
     for (int32_t i = 1; i < env_.size(); ++i) {
       displ[i] = displ[i - 1] + hist[i - 1];
       displ_length[i] = displ_length[i - 1] + hist_length[i - 1];
@@ -131,10 +132,12 @@ public:
         std::copy_n(queries[i].query, queries[i].length, 
           queries_to_distribute.begin() + displ_length[target_pes[i].first]);
         displ_length[target_pes[i].first] += queries[i].length;
+        lengths_to_distribute[displ[target_pes[i].first]++] = queries[i].length;
         if (target_pes[i].first != target_pes[i].second) {
           std::copy_n(queries[i].query, queries[i].length, 
             queries_to_distribute.begin() + displ_length[target_pes[i].second]);
           displ_length[target_pes[i].second] += queries[i].length;
+          lengths_to_distribute[displ[target_pes[i].second]++] = queries[i].length;
         }
       }
     }
@@ -164,8 +167,8 @@ public:
         target_pes[i] = std::make_pair(-1, -1);
       }
     }
-    std::vector<GlobalIndex> displ(env_.size(), 0);
-    std::vector<GlobalIndex> displ_length(env_.size(), 0);
+    std::vector<size_t> displ(env_.size(), 0);
+    std::vector<size_t> displ_length(env_.size(), 0);
     for (int32_t i = 1; i < env_.size(); ++i) {
       displ[i] = displ[i - 1] + hist[i - 1];
       displ_length[i] = displ_length[i - 1] + hist_length[i - 1];
@@ -178,10 +181,12 @@ public:
         std::copy_n(queries[i].query, queries[i].length, 
           queries_to_distribute.begin() + displ_length[target_pes[i].first]);
         displ_length[target_pes[i].first] += queries[i].length;
+        lengths_to_distribute[displ[target_pes[i].first]++] = queries[i].length;
         if (target_pes[i].first != target_pes[i].second) {
           std::copy_n(queries[i].query, queries[i].length, 
             queries_to_distribute.begin() + displ_length[target_pes[i].second]);
           displ_length[target_pes[i].second] += queries[i].length;
+          lengths_to_distribute[displ[target_pes[i].second]++] = queries[i].length;
         }
       }
     }


### PR DESCRIPTION
This pull request (the 3 referenced commits), address multiple functionality-breaking bugs:

### 1) Partition

Say the input file is size `n` and we have `p` processes.

The `distribute_file` function loads `n / p` elements/chars into each of the first p-1 PEs. The last PE gets a local size of `n / p + n % p` elements.

This was not accounted for in the `partition` implementation and consequently resulted in the last PE loading wrong characters during the global trie construction.

This fix adapts the `partition` implementation to keep track of a new member, `min_local_size` which is set to `n / p`, thus allowing all processors to compute target PEs and offset correctly.

### 2) Global trie (compact trie) query algorithm 

This addressed multiple problems in the algorithm for finding the correct processor in the global trie

* corrected the handling of the case when the query mismatches within the path label. The previous code was comparing something very different, and one of the two cases wasn't reachable.

* Corrected the parameters for returning `rightmost_leaf` (should start at current node not previous)

* in `compact_trie.hpp`, changed `RIGHT` and `LEFT` to `MATCH` if the pattern lies within a processor. 

### 3) DPT query algortihms

Problem:
the query lenghts `lengths_to_distribute` were never set (stayed at 0 value), and on the receiving side, the 0-length queries resulted in no actual querying of the local PTs.

Solution:
Set the `lengths_to_distribute` to the correct binned values.