### PR TITLE
Further fixes

### DIFF
--- a/benchmark/dpt.cpp
+++ b/benchmark/dpt.cpp
@@ -22,6 +22,9 @@
 #include "tree/patricia_trie_pointer.hpp"
 #include "util/uint_types.hpp"
 
+using glidx_t = dpt::uint40;
+//using glidx_t = uint64_t;
+
 int32_t main(int32_t argc, char const* argv[]) {
   dpt::mpi::environment env;
   tlx::CmdlineParser cp;
@@ -49,15 +52,15 @@ int32_t main(int32_t argc, char const* argv[]) {
     return -1;
   }
 
-  auto local_text = dpt::mpi::distribute_file<uint8_t, dpt::uint40,
+  auto local_text = dpt::mpi::distribute_file<uint8_t, glidx_t,
                                               uint32_t>(text_file.c_str(), 40);
-  dpt::com::manager<uint8_t, dpt::uint40, uint32_t> com_manager(std::move(local_text));
-  auto local_sa = dpt::mpi::distribute_file<dpt::uint40, dpt::uint40,
+  dpt::com::manager<uint8_t, glidx_t, uint32_t> com_manager(std::move(local_text));
+  auto local_sa = dpt::mpi::distribute_file<glidx_t, glidx_t,
                                             uint32_t>(sa_file.c_str(), 0);
-  auto local_lcp = dpt::mpi::distribute_file<dpt::uint40, dpt::uint40,
+  auto local_lcp = dpt::mpi::distribute_file<glidx_t, glidx_t,
                                              uint32_t>(lcp_file.c_str(), 0);
   
-  dpt::tree::distributed_patricia_trie<uint8_t, dpt::uint40, uint32_t,
+  dpt::tree::distributed_patricia_trie<uint8_t, glidx_t, uint32_t,
                                        dpt::tree::compact_trie_pointer,
                                        dpt::tree::patricia_trie_pointer> dpt(text_file.c_str(),
                                                                              sa_file.c_str(),
@@ -76,9 +79,9 @@ int32_t main(int32_t argc, char const* argv[]) {
       std::exit(-1);
     }
     auto query_text = dpt::mpi::distribute_linewise<uint8_t,
-                                                    dpt::uint40, uint32_t>(query_file, number_queries,
+                                                    glidx_t, uint32_t>(query_file, number_queries,
                                                     30, 0, env);
-    dpt::query::query_list<uint8_t, dpt::uint40,
+    dpt::query::query_list<uint8_t, glidx_t,
                            uint32_t> queries(std::move(query_text), 0, 30);
     start_time = MPI_Wtime();
     if (query_type.compare("co") == 0) {

--- a/dpt/tree/compact_trie.hpp
+++ b/dpt/tree/compact_trie.hpp
@@ -56,11 +56,7 @@ public:
       return { search_state::MATCH, result.position };
     }
     // else we have found a match already
-    assert(search_state::MATCH);
-    if ((result.state == search_state::LEFT_OF && !(result.position & 1UL)) ||
-      (result.state == search_state::RIGHT_OF && (result.position & 1UL))) {
-      return { search_state::NO_MATCH, 0 };
-    }
+    assert(result.state == search_state::MATCH);
     return result;
   }
 
@@ -87,7 +83,7 @@ public:
       return { search_state::MATCH, result.left_position, result.right_position };
     }
     // else we have found a match already
-    assert(search_state::MATCH);
+    assert(result.state == search_state::MATCH);
     return result;
   }
 

--- a/dpt/tree/distributed_patricia_trie.hpp
+++ b/dpt/tree/distributed_patricia_trie.hpp
@@ -126,7 +126,7 @@ public:
     }
     std::vector<Alphabet> queries_to_distribute(
       displ_length.back() + hist_length.back());
-    std::vector<LocalIndex> lengths_to_distribute(queries.size());
+    std::vector<LocalIndex> lengths_to_distribute(displ.back() + hist.back());
     for (size_t i = 0; i < queries.size(); ++i) {
       if (target_pes[i].first >= 0) {
         std::copy_n(queries[i].query, queries[i].length, 


### PR DESCRIPTION
Hi.

This pull-request fixes some more issues. 

Commit 8316642fc1ee02422ccffafec89bdac7ef61bc8c fixes some issues I introduced in my previous fixes (sorry!).

Other changes:

- added typedef for global index type in `benchmark/dpt.cpp` to make it easier to switch between 40bit and 64bit mode
- added MPI barriers around the benchmark timing (otherwise, the benchmark timing results don't measure the parallel walltime, but only PE0's, which also varies a lot over multiple runs due to startup variance).
- fixed `request_substrings(..)`
